### PR TITLE
Use "linstorcontrollers" when listing controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use `kubectl linstor` you need to be using the Piraeus Operator. You need exa
 in your cluster. You can verify this by running:
 
 ```
-$ kubectl get linstorcontrollers.linstor.linbit.com --all-namespaces
+$ kubectl get linstorcontrollers --all-namespaces
 NAMESPACE   NAME            AGE
 piraeus     piraeus-op-cs   5d21h
 ```

--- a/kubectl-linstor.go
+++ b/kubectl-linstor.go
@@ -121,7 +121,7 @@ func main() {
 	ctx, cancel := ctxsignal.WithTermination(context.Background())
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "kubectl", "get", "--all-namespaces", "linstorcontrollers.linstor.linbit.com", "--output", "jsonpath={.items[*].metadata.namespace},{.items[*].metadata.name}")
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "--all-namespaces", "linstorcontrollers", "--output", "jsonpath={.items[*].metadata.namespace},{.items[*].metadata.name}")
 	out, err := cmd.Output()
 	if err != nil {
 		log.Fatalf("failed to fetch LINSTOR controller resource: %v", err)


### PR DESCRIPTION
Using the full group-kind creates an incompatibility between the Piraeus
and LINBIT branded plugin. It should be safe to assume that only one
of the two CRDs are deployed to a cluster at any one time, making it safe
to use the short-cut "linstorcontrollers" name.