### PR TITLE
add the version command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,6 +21,10 @@ builds:
       - amd64
       - arm64
       - s390x
+    ldflags:
+      - -s
+      - -w
+      - -X main.version={{ .Version }}
 
 archives:
   - format: tar.gz

--- a/kubectl-linstor.go
+++ b/kubectl-linstor.go
@@ -182,6 +182,14 @@ func getControllerPodNamespacedName(ctx context.Context) (string, string, error)
 	return "", "", fmt.Errorf("could not find a managed LINSTOR Controller resource")
 }
 
+func isVersion(args ...string) bool {
+	if len(args) != 1 {
+		return false
+	}
+
+	return args[0] == "version"
+}
+
 func isSosReportDownload(args ...string) bool {
 	if len(args) < 2 {
 		return false
@@ -308,7 +316,16 @@ func rawExec(ctx context.Context, kubectlArgs []string, args ...string) {
 	os.Exit(cmd.ProcessState.ExitCode())
 }
 
+var version = "0.0.0"
+
 func main() {
+	cmdArgs := os.Args[1:]
+
+	if isVersion(cmdArgs...) {
+		fmt.Println(version)
+		return
+	}
+
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
@@ -324,7 +341,6 @@ func main() {
 	}
 
 	toExecArgs = append(toExecArgs, fmt.Sprintf("pod/%s", podName), "--")
-	cmdArgs := os.Args[1:]
 	switch {
 	case isSosReportDownload(cmdArgs...):
 		doSosReportDownload(ctx, namespace, podName, toExecArgs, cmdArgs...)


### PR DESCRIPTION
closes #10 

this was tested by creating the `v0.3.3` git version tag and then executing the following commands:

```bash
$ goreleaser release --skip=publish --clean
...
 • getting and validating git state
    • git state                                      commit=0fbcb9d92034f39ac25158bab00cedef650fc498 branch=rgl-version-command current_tag=v0.3.3 previous_tag=v0.3.2 dirty=false
...
```

```bash
$ ./dist/kubectl-linstor_linux_amd64_v1/kubectl-linstor version
0.3.3
```